### PR TITLE
updating old getclusterinfo module name in doc example

### DIFF
--- a/docs/Cluster Info Module.md
+++ b/docs/Cluster Info Module.md
@@ -129,7 +129,7 @@ Examples
 
 ``` yaml+jinja
   - name: Retrieves VxRail Cluster Information
-    dellemc_vxrail_clusterinfo:
+    dellemc_vxrail_getclusterinfo:
         vxmip: "{{ vxmip }}"
         vcadmin: "{{ vcadmin }}"
         vcpasswd: "{{ vcpasswd }}"


### PR DESCRIPTION
changing "clusterinfo" to "getclusterinfo" to match the current module name in documented examples